### PR TITLE
fix for weekday next run calculation.

### DIFF
--- a/Library/Extension/DateTimeExtensions.cs
+++ b/Library/Extension/DateTimeExtensions.cs
@@ -75,16 +75,24 @@
 
         internal static DateTime NextNWeekday(this DateTime current, int toAdvance)
         {
-            while (!current.IsWeekday())
-                current = current.AddDays(1);
-
+            if (!current.IsWeekday())
+            {
+                toAdvance--;
+                while (!current.IsWeekday())
+                {
+                    current = current.AddDays(1);
+                }
+            }
+            
             while (toAdvance >= 1)
             {
                 toAdvance--;
                 current = current.AddDays(1);
-
+                
                 while (!current.IsWeekday())
+                {
                     current = current.AddDays(1);
+                }
             }
             return current;
         }


### PR DESCRIPTION
NextNWeekday now takes into account initial search for a weekday

👬 

fixes tests and seems like the right behavior.